### PR TITLE
Switch from regex crate to regex-lite

### DIFF
--- a/regex-filtered/Cargo.toml
+++ b/regex-filtered/Cargo.toml
@@ -15,7 +15,7 @@ repository = "https://github.com/ua-parser/uap-rust/"
 [dependencies]
 aho-corasick = "1.1.3"
 itertools = "0.13.0"
-regex = "1.10.4"
+regex-lite = "0.1"
 regex-syntax = "0.8.3"
 
 [dev-dependencies]

--- a/regex-filtered/benches/regex.rs
+++ b/regex-filtered/benches/regex.rs
@@ -1,6 +1,6 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 
-use regex::Regex;
+use regex_lite::Regex;
 
 /// On this trivial syntetic test, the results on an M1P are:
 ///

--- a/ua-parser/Cargo.toml
+++ b/ua-parser/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/ua-parser/uap-rust/"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-regex = "1.10.4"
+regex-lite = "0.1"
 regex-filtered = { version = "0.2.0", path = "../regex-filtered" }
 serde = { version = "1.0.203", features = ["derive"] }
 

--- a/ua-parser/src/lib.rs
+++ b/ua-parser/src/lib.rs
@@ -3,7 +3,7 @@
 #![allow(clippy::empty_docs)]
 #![doc = include_str!("../README.md")]
 
-use regex::Captures;
+use regex_lite::Captures;
 use serde::Deserialize;
 
 pub use regex_filtered::{BuildError, ParseError};
@@ -666,29 +666,6 @@ fn rewrite_regex(re: &str) -> std::borrow::Cow<'_, str> {
             ']' if !escape => {
                 inclass += 1;
             }
-            // no need for special cases because regex allows nesting
-            // character classes, whereas js or python don't \o/
-            'd' if escape => {
-                // idx is d so idx-1 is \\, and we want to exclude it
-                out.push_str(&re[from..idx - 1]);
-                from = idx + 1;
-                out.push_str("[0-9]");
-            }
-            'D' if escape => {
-                out.push_str(&re[from..idx - 1]);
-                from = idx + 1;
-                out.push_str("[^0-9]");
-            }
-            'w' if escape => {
-                out.push_str(&re[from..idx - 1]);
-                from = idx + 1;
-                out.push_str("[A-Za-z0-9_]");
-            }
-            'W' if escape => {
-                out.push_str(&re[from..idx - 1]);
-                from = idx + 1;
-                out.push_str("[^A-Za-z0-9_]");
-            }
             _ => (),
         }
         escape = false;
@@ -736,9 +713,11 @@ mod test_rewrite_regex {
     }
 
     #[test]
-    fn rewrite_classes() {
-        assert_eq!(rewrite(r"\dx"), "[0-9]x");
-        assert_eq!(rewrite(r"\wx"), "[A-Za-z0-9_]x");
-        assert_eq!(rewrite(r"[\d]x"), r"[[0-9]]x");
+    fn dont_rewrite_classes() {
+        assert_eq!(rewrite(r"\dx"), r"\dx");
+        assert_eq!(rewrite(r"\wx"), r"\wx");
+        assert_eq!(rewrite(r"[\d]x"), r"[\d]x");
+        assert_eq!(rewrite(r"[\{}]x"), r"[\{}]x");
+        assert_eq!(rewrite(r"\{\}x"), r"\{\}x");
     }
 }

--- a/ua-parser/src/resolvers.rs
+++ b/ua-parser/src/resolvers.rs
@@ -5,7 +5,7 @@
 // required, if any group is optional that returns `None`.
 
 use crate::Error;
-use regex::Captures;
+use regex_lite::Captures;
 use std::borrow::Cow;
 
 fn get<'s>(c: &Captures<'s>, group: usize) -> Option<&'s str> {


### PR DESCRIPTION
Switches from `regex` to `regex-lite` this massively improves the memory footprint. From ~180 MiB down to ~10 MiB while also heavily reducing allocations from a total of ~1.2 GiB down to ~72 MiB.

I did not make the change configurable via a cargo feature since I assume performance should stay roughly the same due to the optimized lookup using `aho_corasick` (also additive features are awkward for this). If you think these assumptions are wrong please let me know.

Note this is technically a breaking change, I removed the `ParseError:: RegexTooLarge` variant since `regex_lite` does not expose this information. To not make it breaking I can add the (unused) variant back in. But with the switch of the dependency it may make sense to release a 0.3 anyways.

I also removed the rewriting of `\d` character classes (it seems like this is fine for `regex-filtered`), since `regex-lite` already [only matches on ascii](https://docs.rs/regex-lite/0.1.6/regex_lite/#differences-with-the-regex-crate) and it does not support nested character classes, which break the regex.

I validated memory consumption and usage using the `dhat` crate:

##### `tmp/Cargo.toml`:
```rs
[workspace]

[package]
name = "tmp"
version = "0.1.0"
edition = "2021"

[dependencies]
dhat = "0.3"
ua-parser-cratesio = { package = "ua-parser" , version = "0.2" }
ua-parser = { path = "../ua-parser/" }
serde_yaml = "0.8"
humansize = "2"
```

##### `tmp/src/main.rs`:
```rs
#[global_allocator]
static ALLOC: dhat::Alloc = dhat::Alloc;

macro_rules! with_mem {
    ($e:expr) => {{
        let before = dhat::HeapStats::get();
        let result = { $e };
        let after = dhat::HeapStats::get();

        println!(
            "used memory `{}`: peak: {} | total: {} | current: {}",
            stringify!($e),
            humansize::format_size(after.max_bytes, humansize::DECIMAL),
            humansize::format_size(after.total_bytes.saturating_sub(before.total_bytes), humansize::DECIMAL),
            humansize::format_size(after.curr_bytes.saturating_sub(before.curr_bytes), humansize::DECIMAL),
        );

        result
    }};
}

fn main() {
    let _profiler = dhat::Profiler::new_heap();

    drop(with_mem!(uap_updated_lite()));
    drop(with_mem!(uap_crates_io_regex()));

    std::mem::forget(_profiler); // We're not interested in the profile.
}

static UA_REGEXES: &str = include_str!("../../ua-parser/uap-core/regexes.yaml");

fn uap_updated_lite() -> ua_parser::Extractor<'static> {
    let regexes: ua_parser::Regexes<'static> = serde_yaml::from_str(UA_REGEXES).unwrap();
    ua_parser::Extractor::try_from(regexes).unwrap()
}

fn uap_crates_io_regex() -> ua_parser_cratesio::Extractor<'static> {
    let regexes: ua_parser_cratesio::Regexes<'static> = serde_yaml::from_str(UA_REGEXES).unwrap();
    ua_parser_cratesio::Extractor::try_from(regexes).unwrap()
}
```

Output from my local system (`cargo run --release`):

```
used memory `uap_updated_lite()`: peak: 10.59 MB | total: 71.25 MB | current: 9.61 MB
used memory `uap_crates_io_regex()`: peak: 180.72 MB | total: 1.27 GB | current: 179.74 MB
```