### PR TITLE
Make release fully triggered & move tests to a separate ci

### DIFF
--- a/.github/workflows/py-tests.yml
+++ b/.github/workflows/py-tests.yml
@@ -1,0 +1,104 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  wheels:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version:
+          - "3.x"
+          - "pypy-3.10"
+          - "graalpy-24"
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('ua-parser-py/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/pip
+            ~/.cache/pip-graalpy
+          key: ${{ runner.os }}-pip-maturin-${{ matrix.python-version }}
+
+      - uses: PyO3/maturin-action@v1
+        with:
+          args: --release --out dist -m ua-parser-py/Cargo.toml -i python --zig
+          sccache: true
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheels-${{ matrix.python-version }}
+          path: dist/*
+          retention-days: 1
+          compression-level: 0
+
+  tests:
+    needs: wheels
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+          - "3.9"
+          - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
+          - "pypy-3.10"
+          - "graalpy-24"
+
+        include:
+          - wheel: "3.x"
+          - python-version: "pypy-3.10"
+            wheel: "pypy-3.10"
+          - python-version: "graalpy-24"
+            wheel: "graalpy-24"
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/pip
+            ~/.cache/pip-graalpy
+          key: ${{ runner.os }}-pip-${{ matrix.python-version }}
+      - uses: actions/download-artifact@v4
+        with:
+          name: wheels-${{ matrix.wheel }}
+          path: dist
+      - run: python -mpip install --upgrade pip
+      - run: |
+          if ! pip download --only-binary :all: pyyaml > /dev/null 2>&1
+          then
+              sudo apt install libyaml-dev
+          fi
+      - run: python -mpip install pytest pyyaml
+      - run: python -mpip install --find-links dist ua_parser_rs
+      - run: pytest -v -Werror -ra ua-parser-py

--- a/.github/workflows/pychecks.yaml
+++ b/.github/workflows/pychecks.yaml
@@ -3,8 +3,6 @@ name: py checks
 on:
   pull_request:
   push:
-    branches:
-      - main
 
 permissions:
   contents: read

--- a/.github/workflows/pyo3-wheels.yml
+++ b/.github/workflows/pyo3-wheels.yml
@@ -1,10 +1,13 @@
-name: Wheels and Tests
+name: Wheels
 
 on:
-  push:
-    branches: [ main ]
-  pull_request:
   workflow_dispatch:
+    inputs:
+      release:
+        description: 'Push wheels to pypi'
+        type: boolean
+        default: false
+        required: true
 
 permissions:
   contents: read
@@ -69,6 +72,8 @@ jobs:
         with:
           name: wheels-${{ matrix.platform }}-${{ matrix.arch }}-${{ matrix.python-version }}
           path: dist/*
+          retention-days: 1
+          compression-level: 0
 
   sdist:
     runs-on: ubuntu-latest
@@ -85,38 +90,10 @@ jobs:
           name: wheels-sdist
           path: dist
 
-  # TODO: tags don't work because multiple crates in same repo, so
-  # needs some other method of picking versions
-  release:
-    name: Release
-    runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'workflow_dispatch' }}
-    needs: [wheels, sdist]
-    permissions:
-      # Use to sign the release artifacts
-      id-token: write
-      # Used to upload release artifacts
-      contents: write
-      # Used to generate artifact attestation
-      attestations: write
-    environment: release
-    steps:
-      - uses: actions/download-artifact@v4
-      - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@v1
-        with:
-          subject-path: 'wheels-*/*'
-      - name: Publish to PyPI
-        uses: PyO3/maturin-action@v1
-        with:
-          command: upload
-          args: --non-interactive --skip-existing wheels-*/*
-
   tests:
     needs: wheels
     
     strategy:
-      fail-fast: false
       matrix:
         python-version:
           - "3.9"
@@ -190,3 +167,28 @@ jobs:
         run: pip install --find-links dist ua_parser_rs
       - name: Run tests
         run: pytest -v -Werror -ra ua-parser-py
+
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    needs: [tests, sdist]
+    if: ${{ inputs.release == 'true' }}
+    permissions:
+      # Use to sign the release artifacts
+      id-token: write
+      # Used to upload release artifacts
+      contents: write
+      # Used to generate artifact attestation
+      attestations: write
+    environment: release
+    steps:
+      - uses: actions/download-artifact@v4
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: 'wheels-*/*'
+      - name: Publish to PyPI
+        uses: PyO3/maturin-action@v1
+        with:
+          command: upload
+          args: --non-interactive --skip-existing wheels-*/*

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,8 +3,6 @@ name: Rust
 on:
   pull_request:
   push:
-    branches:
-      - main
 
 env:
   CARGO_TERM_COLOR: always

--- a/ua-parser-py/pyproject.toml
+++ b/ua-parser-py/pyproject.toml
@@ -4,10 +4,13 @@ build-backend = "maturin"
 
 [project]
 name = "ua-parser-rs"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers = [
     "Programming Language :: Rust",
     "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
     # "Programming Language :: Python :: Implementation :: GraalPy",


### PR DESCRIPTION
Building the wheels for every PR / push is mostly unnecessary, technically one wheel could be broken and the rest not, but ua-parser doesn't actually have anything OS (or architecture) specific, so the odds seem pretty low.

Therefore stop doing that, move the wheels / release workflow to full triggered, and extract basic wheels (ubutun & amd64 only) and tests to a separate CI for regular testing.

Fixes #9, #8, #6.