### PR TITLE
Fix job names so they can be selected as required statuses

### DIFF
--- a/.github/workflows/py-checks.yml
+++ b/.github/workflows/py-checks.yml
@@ -8,7 +8,7 @@ permissions:
   contents: read
 
 jobs:
-  checks:
+  py-checks:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout working copy

--- a/.github/workflows/py-tests.yml
+++ b/.github/workflows/py-tests.yml
@@ -8,7 +8,7 @@ permissions:
   contents: read
 
 jobs:
-  wheels:
+  py-test-wheels:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -53,8 +53,8 @@ jobs:
           retention-days: 1
           compression-level: 0
 
-  tests:
-    needs: wheels
+  py-tests:
+    needs: py-test-wheels
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/pyo3-wheels.yml
+++ b/.github/workflows/pyo3-wheels.yml
@@ -13,7 +13,7 @@ permissions:
   contents: read
 
 jobs:
-  wheels:
+  py-release-wheels:
     strategy:
       matrix:
         python-version:
@@ -75,7 +75,7 @@ jobs:
           retention-days: 1
           compression-level: 0
 
-  sdist:
+  py-release-sdist:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -90,8 +90,8 @@ jobs:
           name: wheels-sdist
           path: dist
 
-  tests:
-    needs: wheels
+  py-release-tests:
+    needs: py-release-wheels
     
     strategy:
       matrix:
@@ -168,10 +168,10 @@ jobs:
       - name: Run tests
         run: pytest -v -Werror -ra ua-parser-py
 
-  release:
+  py-release:
     name: Release
     runs-on: ubuntu-latest
-    needs: [tests, sdist]
+    needs: [py-release-tests, py-release-sdist]
     if: ${{ inputs.release == 'true' }}
     permissions:
       # Use to sign the release artifacts

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,7 +8,18 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  checks:
+  rust-checks:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Format
+      run: cargo fmt --check
+    - name: clippy
+      if: always()
+      run: cargo clippy
+
+  rust-tests:
     runs-on: ubuntu-latest
 
     steps:
@@ -17,9 +28,5 @@ jobs:
         submodules: true
     - name: Check
       run: cargo check
-    - name: Format
-      run: cargo fmt --check
-    - name: clippy
-      run: cargo clippy
     - name: Run tests
       run: cargo test -r --verbose


### PR DESCRIPTION
Usually there are not many jobs and they don't overlap so their naming is easy. In this case I forgot that statuses are per-job not per file or anything, so

- the naming overlap between the "normal" python tests and the release made knowing which was which much harder than necessary
- the rust and python checks literally having the same job name made one of them (not sure which) impossible to select
- having all the rust stuff as a single "checks" jobs didn't help either, split it into checks and tests to more or less mirror the python stuff
- prefix jobs with their language as it's not out the question that the repository would grow e.g. JS bindings in neon, or a C API for FFI, or whatever, and those would need to be clearly identified