### PR TITLE
Add some metadata to ua-parser-py

### DIFF
--- a/ua-parser-py/Cargo.toml
+++ b/ua-parser-py/Cargo.toml
@@ -1,8 +1,12 @@
 [package]
 name = "ua-parser-rs"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "Apache 2.0"
+description = "A native accelerator for uap-python"
+repository = "https://github.com/ua-parser/uap-rust/"
+homepage = "https://github.com/ua-parser/uap-rust/blob/main/ua-parser/"
+authors = ["masklinn <uap@masklinn.net>"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]
@@ -10,5 +14,5 @@ name = "ua_parser_rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.22", features = ["extension-module", "abi3", "abi3-py38"] }
+pyo3 = { version = "0.22", features = ["extension-module", "abi3", "abi3-py39"] }
 ua-parser = { version = "0.2.0", path = "../ua-parser" }

--- a/ua-parser-py/README.md
+++ b/ua-parser-py/README.md
@@ -1,0 +1,14 @@
+a ua-parser accelerator
+=======================
+
+This package is (currently) not intended to be used directly, instead
+it is one of the native accelerators for [ua-parser][1].
+
+The API is very simplistic and should be pretty stable (if only
+because having to update [ua-parser][1] all the time is undesirable),
+but there is no formal guarantee that it'll keep, as the goal is
+really nothing more than a very basic export of [uap-rust][2] to
+Python.
+
+[1]: https://pypi.org/project/ua-parser/
+[2]: https://crates.io/crates/ua-parser


### PR DESCRIPTION
While it's not really in need of documentation as it's an implementation detail of uap-python, opening the link to the dependency from the main package and seeing an empty page is rather suspicious.

Adding info / metadata would, I hope and assume, assuage fears.

Fixes #13 