### PR TITLE
New release of ua-parser and wheel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -663,7 +663,7 @@ dependencies = [
 
 [[package]]
 name = "ua-parser"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "clap",
  "regex",
@@ -675,7 +675,7 @@ dependencies = [
 
 [[package]]
 name = "ua-parser-rs"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "pyo3",
  "ua-parser",

--- a/ua-parser-py/Cargo.toml
+++ b/ua-parser-py/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ua-parser-rs"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 license = "Apache 2.0"
 description = "A native accelerator for uap-python"
@@ -15,4 +15,4 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pyo3 = { version = "0.24", features = ["extension-module", "abi3", "abi3-py39"] }
-ua-parser = { version = "0.2.0", path = "../ua-parser" }
+ua-parser = { version = "0.2.1", path = "../ua-parser" }

--- a/ua-parser/Cargo.toml
+++ b/ua-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ua-parser"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "Rust implementation of the User Agent String Parser project"


### PR DESCRIPTION
The memory gains from fixing regex rewriting
(2d289cbbceb52d9510dfb0490f0155b487f38398) and performance gains from tuning atom size (3d70b3703176b23411dd0cb29dfabf818e9771dd) are significant enough for a new release, and I clearly can't be arsed to implement a bunch of benchmarks, so stop waiting for that.