### PR TITLE
Fix wheels action fuckup

### DIFF
--- a/.github/workflows/pyo3-wheels.yml
+++ b/.github/workflows/pyo3-wheels.yml
@@ -224,7 +224,7 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     needs: [py-release-tests, py-release-sdist]
-    if: github.event == 'workflow_dispatch' && inputs.release
+    if: github.event_name == 'workflow_dispatch' && inputs.release
     permissions:
       # Use to sign the release artifacts
       id-token: write


### PR DESCRIPTION
`github.event` is the full webhook payload so it never matches a string literal...