### PR TITLE
Derive Clone for Value and ValueRef

### DIFF
--- a/ua-parser/src/lib.rs
+++ b/ua-parser/src/lib.rs
@@ -253,7 +253,7 @@ pub mod user_agent {
     /// Borrowed extracted value, borrows the content of the original
     /// parser or the content of the user agent string, unless a
     /// replacement is performed. (which is only possible for the )
-    #[derive(PartialEq, Eq, Default, Debug)]
+    #[derive(PartialEq, Eq, Default, Debug, Clone)]
     pub struct ValueRef<'a> {
         ///
         pub family: Cow<'a, str>,
@@ -284,7 +284,7 @@ pub mod user_agent {
 
     /// Owned extracted value, identical to [`ValueRef`] but not
     /// linked to either the UA string or the extractor.
-    #[derive(PartialEq, Eq, Default, Debug)]
+    #[derive(PartialEq, Eq, Default, Debug, Clone)]
     pub struct Value {
         ///
         pub family: String,
@@ -417,7 +417,7 @@ pub mod os {
     }
 
     /// An OS extraction result.
-    #[derive(PartialEq, Eq, Default, Debug)]
+    #[derive(PartialEq, Eq, Default, Debug, Clone)]
     pub struct ValueRef<'a> {
         ///
         pub os: Cow<'a, str>,
@@ -447,7 +447,7 @@ pub mod os {
     }
 
     /// Owned version of [`ValueRef`].
-    #[derive(PartialEq, Eq, Default, Debug)]
+    #[derive(PartialEq, Eq, Default, Debug, Clone)]
     pub struct Value {
         ///
         pub os: String,
@@ -581,7 +581,7 @@ pub mod device {
 
     /// Extracted device content, may borrow from one of the
     /// [`Parser`] or from the user agent string.
-    #[derive(PartialEq, Eq, Default, Debug)]
+    #[derive(PartialEq, Eq, Default, Debug, Clone)]
     pub struct ValueRef<'a> {
         ///
         pub device: Cow<'a, str>,
@@ -606,7 +606,7 @@ pub mod device {
     }
 
     /// Owned version of [`ValueRef`].
-    #[derive(PartialEq, Eq, Default, Debug)]
+    #[derive(PartialEq, Eq, Default, Debug, Clone)]
     pub struct Value {
         ///
         pub device: String,


### PR DESCRIPTION
Not having `Clone` on `Value` makes it very difficult to store extracted values in a cache, and there seems to be no reason I can see to not implement `Clone` on `ValueRef` as well, since there are legitimate use-cases for it and it is impossible for downstream consumers to implement Clone themselves.