### PR TITLE
CI compatibility bumps

### DIFF
--- a/.github/workflows/py-tests.yml
+++ b/.github/workflows/py-tests.yml
@@ -14,15 +14,16 @@ jobs:
       matrix:
         python-version:
           - "3.x"
-          - "pypy-3.10"
+          - "3.14t"
           - "pypy-3.11"
           - "graalpy-24"
+          - "graalpy-25"
 
     steps:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -63,30 +64,32 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"
           - "3.13"
-          - "pypy-3.10"
+          - "3.14t"
           - "pypy-3.11"
           - "graalpy-24"
+          - "graalpy-25"
 
         include:
           - wheel: "3.x"
-          - python-version: "pypy-3.10"
-            wheel: "pypy-3.10"
+          - python-version: "3.14t"
+            wheel: "3.14t"
           - python-version: "pypy-3.11"
             wheel: "pypy-3.11"
           - python-version: "graalpy-24"
             wheel: "graalpy-24"
+          - python-version: "graalpy-25"
+            wheel: "graalpy-25"
 
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: true
           persist-credentials: false
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true

--- a/.github/workflows/pyo3-wheels.yml
+++ b/.github/workflows/pyo3-wheels.yml
@@ -34,7 +34,7 @@ jobs:
               ('linux', 'aarch64'): 'ubuntu-24.04-arm',
               ('musllinux', 'x86_64'): 'ubuntu-latest',
               ('musllinux', 'aarch64'): 'ubuntu-24.04-arm',
-              ('macos', 'x86_64'): 'macos-13',
+              ('macos', 'x86_64'): 'macos-15-intel',
               ('macos', 'aarch64'): 'macos-latest',
               ('windows', 'x86_64'): 'windows-latest',
               ('windows', 'aarch64'): 'windows-11-arm',
@@ -43,18 +43,14 @@ jobs:
           matrix = [
               d
               for d in map(dict, itertools.product(
-                  (('python-version', v) for v in ["3.x", "pypy-3.10", "pypy-3.11", "graalpy-24"]),
+                  (('python-version', v) for v in ["3.x", "3.14t", "pypy-3.11", "graalpy-24", "graalpy-25"]),
                   (('arch', a) for a in ["x86_64", "aarch64"]),
                   (('platform', p) for p in ["linux", "musllinux", "windows", "macos"])
               ))
               # on windows, only cpython has arm builds (?)
-              if not (
-                  d['platform'] == 'windows'
-              and d['arch'] == 'aarch64'
-              and d['python-version'] != '3.x'
-              )
-              # windows and graal don't work
-              if not (d['platform'] == 'windows' and d['python-version'] == 'graalpy-24')
+              if d['python-version'].startswith('3.') \
+              or d['platform'] != 'windows' \
+              or d['arch'] != 'aarch64'
           ]
           for job in matrix:
               match job['platform']:
@@ -83,7 +79,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       # windows/arm doesn't have a rust toolchain by default
@@ -127,14 +123,15 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"
           - "3.13"
-          - "pypy-3.10"
+          - "3.14"
+          - "3.14t"
           - "pypy-3.11"
           - "graalpy-24"
+          - "graalpy-25"
         platform:
           - linux
           # probably requires a custom image of some sort
@@ -147,28 +144,26 @@ jobs:
 
         exclude:
           - platform: windows
-            arch: aarch64
-            python-version: 3.9
-          - platform: windows
             python-version: 3.10
             arch: aarch64
-          - platform: windows
-            arch: aarch64
-            python-version: pypy-3.10
           - platform: windows
             arch: aarch64
             python-version: pypy-3.11
           - platform: windows
             python-version: graalpy-24
+          - platform: windows
+            python-version: graalpy-25
 
         include:
           - wheel: "3.x"
-          - python-version: "pypy-3.10"
-            wheel: "pypy-3.10"
+          - python-version: "3.14t"
+            wheel: "3.14t"
           - python-version: "pypy-3.11"
             wheel: "pypy-3.11"
           - python-version: "graalpy-24"
             wheel: "graalpy-24"
+          - python-version: "graalpy-25"
+            wheel: "graalpy-25"
 
           - runner: ubuntu-latest
           - arch: aarch64
@@ -182,7 +177,7 @@ jobs:
             runner: macos-latest
           - platform: macos
             arch: x86_64
-            runner: macos-13
+            runner: macos-15-intel
 
     runs-on: ${{ matrix.runner }}
 
@@ -193,7 +188,7 @@ jobs:
           submodules: true
           persist-credentials: false
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -431,11 +431,10 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.24.2"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5203598f366b11a02b13aa20cab591229ff0a89fd121a308a5df751d5fc9219"
+checksum = "ab53c047fcd1a1d2a8820fe84f05d6be69e9526be40cb03b73f86b6b03e6d87d"
 dependencies = [
- "cfg-if",
  "indoc",
  "libc",
  "memoffset",
@@ -449,19 +448,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.24.2"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99636d423fa2ca130fa5acde3059308006d46f98caac629418e53f7ebb1e9999"
+checksum = "b455933107de8642b4487ed26d912c2d899dec6114884214a0b3bb3be9261ea6"
 dependencies = [
- "once_cell",
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.24.2"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78f9cf92ba9c409279bc3305b5409d90db2d2c22392d443a87df3a1adad59e33"
+checksum = "1c85c9cbfaddf651b1221594209aed57e9e5cff63c4d11d1feead529b872a089"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -469,9 +467,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.24.2"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b999cb1a6ce21f9a6b147dcf1be9ffedf02e0043aec74dc390f3007047cecd9"
+checksum = "0a5b10c9bf9888125d917fb4d2ca2d25c8df94c7ab5a52e13313a07e050a3b02"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -481,9 +479,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.24.2"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "822ece1c7e1012745607d5cf0bcb2874769f0f7cb34c4cde03b9358eb9ef911a"
+checksum = "03b51720d314836e53327f5871d4c0cfb4fb37cc2c4a11cc71907a86342c40f9"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/regex-filtered/src/model.rs
+++ b/regex-filtered/src/model.rs
@@ -382,7 +382,7 @@ impl Visitor for InfoVisitor {
                     } else {
                         Info::Exact(
                             c.iter()
-                                .flat_map(|r| (r.start()..=r.end()))
+                                .flat_map(|r| r.start()..=r.end())
                                 .map(char::to_lowercase)
                                 .map(String::from_iter)
                                 .map(LengthThenLex)

--- a/ua-parser-py/Cargo.toml
+++ b/ua-parser-py/Cargo.toml
@@ -14,5 +14,5 @@ name = "ua_parser_rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.24", features = ["extension-module", "abi3", "abi3-py39"] }
+pyo3 = { version = "0.27", features = ["extension-module", "abi3", "abi3-py310"] }
 ua-parser = { version = "0.2.1", path = "../ua-parser" }

--- a/ua-parser-py/pyproject.toml
+++ b/ua-parser-py/pyproject.toml
@@ -6,14 +6,14 @@ build-backend = "maturin"
 name = "ua-parser-rs"
 description = "native accelerator for ua-parser"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Rust",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
     "Programming Language :: Python :: Implementation :: GraalPy",

--- a/ua-parser-py/src/lib.rs
+++ b/ua-parser-py/src/lib.rs
@@ -193,7 +193,7 @@ impl DeviceExtractor {
     }
 }
 
-#[pymodule]
+#[pymodule(gil_used = false)]
 fn ua_parser_rs(m: &Bound<PyModule>) -> PyResult<()> {
     m.add_class::<UserAgentExtractor>()?;
     m.add_class::<OSExtractor>()?;

--- a/ua-parser-py/tox.ini
+++ b/ua-parser-py/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-env_list = py{39,310,311,312,313}, pypy{3.10,3.11}#, graalpy
+env_list = py{310,311,312,313,314,314t}, pypy3.11, graalpy-{24,25}
          , typecheck, format, lint
 skip_missing_interpreters = true
 


### PR DESCRIPTION
Add testing and wheels-building for:

- free-threaded python
- graal 25

Remove support for

- pypy 3.10 (support ended with pypy 7.3.20 in July 2025)
- cpython 3.9 (support ended in October 2025)

Note that on my machine at least tox does not seem to handle wheels correctly for 3.14t, graal 24, and graal 25. It tries to run all of them with the cp310-abi3 wheel.

Fixes #41, fixes #42, fixes #43