### PR TITLE
Bump version of ua-parser-rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -711,7 +711,7 @@ dependencies = [
 
 [[package]]
 name = "ua-parser-rs"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "pyo3",
  "ua-parser",

--- a/ua-parser-py/Cargo.toml
+++ b/ua-parser-py/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ua-parser-rs"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2024"
 license = "Apache 2.0"
 description = "A native accelerator for uap-python"


### PR DESCRIPTION
Needed for graal 25 (/ 3.12) compatibility. Fixes #47.