### PR TITLE
Fix resource exhaustion risk

### DIFF
--- a/regex-filtered/src/mapper.rs
+++ b/regex-filtered/src/mapper.rs
@@ -380,11 +380,46 @@ mod test {
         );
 
         let mut b = Builder::new(0);
-
         b.push(Model::new(&parse("test(xy|zt){10}").unwrap()).unwrap());
         let (_, mut atoms) = b.build();
         atoms.sort();
         assert_eq!(&*atoms, ["test", "xy", "zt"]);
+
+        let mut b = Builder::new(0);
+        b.push(Model::new(&parse("x{10}a").unwrap()).unwrap());
+        let (_, mut atoms) = b.build();
+        atoms.sort();
+        assert_eq!(&*atoms, ["xxxxxxxxxxa"]);
+
+        let mut b = Builder::new(0);
+        b.push(Model::new(&parse("x{10,11}a").unwrap()).unwrap());
+        let (_, mut atoms) = b.build();
+        atoms.sort();
+        assert_eq!(&*atoms, ["a", "xxxxxxxxxx"]);
+
+        let mut b = Builder::new(0);
+        b.push(Model::new(&parse("(ab|cd?){10}").unwrap()).unwrap());
+        let (_, mut atoms) = b.build();
+        atoms.sort();
+        assert_eq!(&*atoms, ["ab", "c"]);
+    }
+
+    /// re2 limits repetitions to 1000 which limits the size explosion
+    /// of atoms, regexp does not mind any repetition which can
+    /// trigger resource extension in filtered during repetition expansion
+    #[test]
+    fn repetition_excessive() {
+        let mut b = Builder::new(0);
+        b.push(Model::new(&parse("x{10000000}").unwrap()).unwrap());
+        let (_, atoms) = b.build();
+        assert_eq!(atoms.len(), 1);
+        assert!(atoms[0].len() < 4_000);
+
+        let mut b = Builder::new(0);
+        b.push(Model::new(&parse("x{10000000}a").unwrap()).unwrap());
+        let (_, atoms) = b.build();
+        assert_eq!(atoms.len(), 2);
+        assert!(atoms.contains(&String::from("a")));
     }
 
     #[test]

--- a/regex-filtered/src/model.rs
+++ b/regex-filtered/src/model.rs
@@ -411,10 +411,18 @@ impl Visitor for InfoVisitor {
                         match arg {
                             Info::Exact(mut arg) if arg.len() == 1 => {
                                 let s = arg.pop_first().unwrap();
-                                let set = [LengthThenLex(s.repeat(min as _))].into();
-                                if Some(min) == *max {
+                                let minsize = min as usize;
+                                // re2 limits repetitions to 1000, but
+                                // allows literal with ~no length
+                                // limit to be repeated which feels a
+                                // bit strange and irregular, instead
+                                // limit atoms expansion to 2KB
+                                if Some(min) == *max && (minsize * s.len() < 2048) {
+                                    let set = [LengthThenLex(s.repeat(minsize))].into();
                                     self.stack.push(Info::Exact(set));
                                 } else {
+                                    let min = (2048 / s.len()).clamp(1, minsize);
+                                    let set = [LengthThenLex(s.repeat(min))].into();
                                     self.stack.push(Info::Match(Model::or_strings(set)));
                                 }
                             }
@@ -441,9 +449,7 @@ impl Visitor for InfoVisitor {
                                 }
                             }
                             arg => {
-                                let m = std::iter::repeat_n(arg.take_match(), min as _)
-                                    .fold(Model::all(), Model::and);
-                                self.stack.push(Info::Match(m));
+                                self.stack.push(Info::Match(arg.take_match()));
                             }
                         }
                     }


### PR DESCRIPTION
regex-filtered would naively expand repetitions of literals via `String::repeat`, but regex does not bound repetitions at all (in the parser anyway, the compiler apparenly bounds repetitions to 2**16-1), which could lead to complete resource exhaustion and crash in case of untrusted regex.

FilteredRE2 is (somewhat) protected from this issue because apparently re2 hard-limits repetitions to 1000. However the atom size is apparently irrelevant to the limit (same with regex's compiler), but because we're expanding the atom here it seems like it's a good idea to consider that, so cut off the atom at 2KB after expansion.

And in the case a `Match`, drop the repetition entirely, it's just wasting tons of cycles for no purpose: ultimately the nodes are deduplicated and associated with their parents, so multiple identical children with the same parent are redundant e.g. `(ab|cd?){n}` yields just the atoms `ab` and `c` no matter the value of `n`.