### PR TITLE
Make sure an alternation with an empty literal doesn't break

### DIFF
--- a/regex-filtered/src/lib.rs
+++ b/regex-filtered/src/lib.rs
@@ -439,4 +439,14 @@ mod test {
             .push_all(b"a\nb\nc\nd\n".lines().map(|l| l.unwrap()))
             .unwrap();
     }
+
+    #[test]
+    fn alternate() {
+        let f = Builder::new().push("abc|").unwrap().build().unwrap();
+        assert_eq!(
+            f.matching("abcde").map(|(idx, _)| idx).collect_vec(),
+            vec![0],
+        );
+        assert_eq!(f.matching("xyz").map(|(idx, _)| idx).collect_vec(), vec![0],);
+    }
 }

--- a/regex-filtered/src/mapper.rs
+++ b/regex-filtered/src/mapper.rs
@@ -519,4 +519,13 @@ mod test {
         atoms.sort();
         assert_eq!(&*atoms, &[" - ", " - sony", "android application",])
     }
+
+    #[test]
+    fn test_alternate_empty() {
+        let mut b = Builder::new(0);
+        b.push(Model::new(&parse("a|").unwrap()).unwrap());
+        let (_, mut atoms) = b.build();
+        atoms.sort();
+        assert_eq!(&*atoms, ["", "a"]);
+    }
 }


### PR DESCRIPTION
Gemini's code review got me doubting, and I didn't leave a comment (beside copying over from re2), but I think this is a somewhat magical error special case, because an empty literal should be a `HirKind::Empty`.

It might actually be a special case in re2 exclusively and dead code for us, it certainly doesn't seem like any test case goes through that code path.