### PR TITLE
Don't use an IntSet for the regexps when mapping atoms to regex

### DIFF
--- a/regex-filtered/src/int_set.rs
+++ b/regex-filtered/src/int_set.rs
@@ -25,10 +25,6 @@ impl IntSet {
     pub fn len(&self) -> usize {
         self.dense.len()
     }
-
-    pub fn into_vec(self) -> Vec<usize> {
-        self.dense
-    }
 }
 
 impl std::ops::Index<usize> for IntSet {

--- a/regex-filtered/src/mapper.rs
+++ b/regex-filtered/src/mapper.rs
@@ -187,7 +187,7 @@ impl Display for Mapper {
             writeln!(f, "\tatom {i} -> entry {e}")?;
             let mut s = IntSet::new(self.entries.len());
             s.insert(e);
-            for r in self.propagate_match(&mut s).into_vec() {
+            for r in self.propagate_match(&mut s) {
                 writeln!(f, "\t\tregex {r}")?;
             }
         }
@@ -250,7 +250,7 @@ impl Mapper {
         let mut matched_atom_ids = IntSet::new(self.entries.len());
         matched_atom_ids.extend(atoms.into_iter().map(|idx| self.atom_to_entry[idx]));
 
-        let mut regexps = self.propagate_match(&mut matched_atom_ids).into_vec();
+        let mut regexps = self.propagate_match(&mut matched_atom_ids);
 
         regexps.extend(&self.unfiltered);
 
@@ -258,10 +258,10 @@ impl Mapper {
         regexps
     }
 
-    fn propagate_match(&self, work: &mut IntSet) -> IntSet {
+    fn propagate_match(&self, work: &mut IntSet) -> Vec<usize> {
         let mut count = vec![0; self.entries.len()];
 
-        let mut regexps = IntSet::new(self.regexp_count);
+        let mut regexps = Vec::with_capacity(self.regexp_count);
 
         let mut i = 0;
         while i < work.len() {
@@ -332,10 +332,10 @@ mod test {
         assert_eq!(&m.atom_to_entry, &[0, 1]);
         let mut s = IntSet::new(3);
         s.insert(0);
-        assert_eq!(m.propagate_match(&mut s).into_vec(), vec![0]);
+        assert_eq!(m.propagate_match(&mut s), vec![0]);
         let mut s = IntSet::new(3);
         s.insert(1);
-        assert_eq!(m.propagate_match(&mut s).into_vec(), vec![0]);
+        assert_eq!(m.propagate_match(&mut s), vec![0]);
     }
 
     #[test]


### PR DESCRIPTION
re2 uses a straight vector and doesn't bother any further, I assume this was originally a hashset due to concerns about duplicates, then it got converted through to an `IntSet` as that got used for the propagation state.

Saves an allocation and a minor amount of indirection in extend, but doesn't otherwise seem to have a significant effect.